### PR TITLE
Refine ribbon handlers and schedule generation

### DIFF
--- a/ArgusExcelTools/ArgusExcelTools.csproj
+++ b/ArgusExcelTools/ArgusExcelTools.csproj
@@ -185,28 +185,36 @@
     can be found.
   -->
   <ItemGroup>
-    <Compile Include="Argus.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="Argus.Designer.cs">
-      <DependentUpon>Argus.cs</DependentUpon>
-    </Compile>
-    <Compile Include="CableScheduleBuilder.cs" />
-    <Compile Include="CableTrayScheduleBuilder.cs" />
-    <Compile Include="CreateScheduleHelper.cs" />
-    <Compile Include="DuctbankScheduleBuilder.cs" />
-    <Compile Include="Equipment.cs" />
-    <Compile Include="MechanicalObject.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
+      <Compile Include="Argus.cs">
+        <SubType>Component</SubType>
+      </Compile>
+      <Compile Include="Argus.Designer.cs">
+        <DependentUpon>Argus.cs</DependentUpon>
+      </Compile>
+      <Compile Include="ArgusRibbon.cs" />
+      <Compile Include="Cable.cs" />
+      <Compile Include="CableScheduleBuilder.cs" />
+      <Compile Include="CableTrayScheduleBuilder.cs" />
+      <Compile Include="CableTraceProcessor.cs" />
+      <Compile Include="CableLibrary.cs" />
+      <Compile Include="CreateScheduleHelper.cs" />
+      <Compile Include="DuctbankScheduleBuilder.cs" />
+      <Compile Include="ConduitLibrary.cs" />
+      <Compile Include="Equipment.cs" />
+      <Compile Include="MechanicalObject.cs" />
+      <Compile Include="Properties\AssemblyInfo.cs">
+        <SubType>Code</SubType>
+      </Compile>
     <Compile Include="Pump.cs" />
-    <Compile Include="Valve.cs" />
-    <Compile Include="MechCsvProcessor.cs" />
-    <Compile Include="Vessel.cs" />
-    <EmbeddedResource Include="Argus.resx">
-      <DependentUpon>Argus.cs</DependentUpon>
-    </EmbeddedResource>
+      <Compile Include="Valve.cs" />
+      <Compile Include="MechCsvProcessor.cs" />
+      <Compile Include="Vessel.cs" />
+      <Compile Include="Raceway.cs" />
+      <Compile Include="TraceResult.cs" />
+      <Compile Include="ScheduleGenerator.cs" />
+      <EmbeddedResource Include="Argus.resx">
+        <DependentUpon>Argus.cs</DependentUpon>
+      </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>

--- a/ArgusExcelTools/ArgusRibbon.cs
+++ b/ArgusExcelTools/ArgusRibbon.cs
@@ -11,7 +11,7 @@ namespace ArgusElectrical
         private RibbonButton cableTraceButton;
         private RibbonButton generateScheduleButton;
 
-        private TraceResult? traceContext;
+        private TraceResult traceContext;
 
         public ArgusRibbon()
             : base(Globals.Factory.GetRibbonFactory())

--- a/ArgusExcelTools/ScheduleGenerator.cs
+++ b/ArgusExcelTools/ScheduleGenerator.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace ArgusElectrical
+{
+    internal class ScheduleGenerator
+    {
+        public void Generate(Excel.Workbook workbook, TraceResult context)
+        {
+            if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var sheet = GetOrCreateSheet(workbook, "Cable Schedule");
+            sheet.Cells.Clear();
+
+            string[] headers = { "CABLE ID", "FROM", "TO", "QTY", "SIZE", "TYPE", "GND", "RACEWAY ROUTING", "SIGNAL TYPE" };
+            for (int i = 0; i < headers.Length; i++)
+            {
+                sheet.Cells[1, i + 1] = headers[i];
+            }
+
+            int row = 2;
+            foreach (var cable in context.Cables)
+            {
+                sheet.Cells[row, 1] = cable.ID;
+                sheet.Cells[row, 2] = cable.From;
+                sheet.Cells[row, 3] = cable.To;
+                sheet.Cells[row, 4] = cable.Quantity;
+                sheet.Cells[row, 5] = cable.Size;
+                sheet.Cells[row, 6] = cable.Type;
+                sheet.Cells[row, 7] = cable.Ground;
+                sheet.Cells[row, 8] = cable.RacewayRouting;
+                sheet.Cells[row, 9] = cable.SignalType;
+                row++;
+            }
+
+            sheet.Columns.AutoFit();
+        }
+
+        private Excel.Worksheet GetOrCreateSheet(Excel.Workbook workbook, string name)
+        {
+            var sheet = workbook.Worksheets.Cast<Excel.Worksheet>().FirstOrDefault(w => w.Name == name);
+            if (sheet == null)
+            {
+                sheet = workbook.Worksheets.Add();
+                sheet.Name = name;
+            }
+            return sheet;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add ScheduleGenerator to build a cable schedule worksheet from trace results
- Wire ribbon buttons to trace cables and build schedule, retaining trace context
- Register new classes in project file so they compile with the add-in

## Testing
- `dotnet build ArgusExcelTools.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892ceb54604832f8d3c4ca1df627c97