### PR TITLE
Implement cable trace cross-check and logging

### DIFF
--- a/ArgusExcelTools/CableTraceProcessor.cs
+++ b/ArgusExcelTools/CableTraceProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.IO;
 using Excel = Microsoft.Office.Interop.Excel;
 
 namespace ArgusExcelTools
@@ -22,14 +23,27 @@ namespace ArgusExcelTools
 
             var cablesSheet = workbook.Worksheets.Cast<Excel.Worksheet>().FirstOrDefault(w => w.Name == "Cables");
             var racewaySheet = workbook.Worksheets.Cast<Excel.Worksheet>().FirstOrDefault(w => w.Name == "Raceway");
+            var ductbankSheet = workbook.Worksheets.Cast<Excel.Worksheet>().FirstOrDefault(w => w.Name == "Ductbank");
+            var traySheet = workbook.Worksheets.Cast<Excel.Worksheet>().FirstOrDefault(w => w.Name == "Cable Tray");
             if (cablesSheet == null || racewaySheet == null)
             {
                 throw new InvalidOperationException("Required worksheets 'Cables' and 'Raceway' are missing.");
             }
 
+            var ductbanks = ductbankSheet != null ? BuildDuctbankList(ductbankSheet) : new List<Ductbank>();
+            var trays = traySheet != null ? BuildCableTrayList(traySheet) : new List<CableTray>();
+
             BuildCableList(cablesSheet, result.Cables);
             BuildRacewayList(racewaySheet, result.Raceways);
             ApplyRacewaySizing(racewaySheet, result);
+
+            var folder = workbook.Path;
+            if (!string.IsNullOrEmpty(folder))
+            {
+                ValidateCableTray(trays, result.Cables, folder);
+                ValidateDuctbank(ductbanks, result.Raceways, folder);
+                ValidateCableRaceway(result.Cables, result.Raceways, folder);
+            }
 
             return result;
         }
@@ -104,6 +118,100 @@ namespace ArgusExcelTools
                     DuctbankRouting = ((Excel.Range)sheet.Cells[row, ductbankCol]).Text as string
                 });
             }
+        }
+
+        private List<Ductbank> BuildDuctbankList(Excel.Worksheet sheet)
+        {
+            var ductbanks = new List<Ductbank>();
+            int idCol = FindFirstMatchColumn(sheet, new Regex("^EDB-\\d{1,4}$", RegexOptions.IgnoreCase));
+            if (idCol <= 0)
+            {
+                return ductbanks;
+            }
+
+            var racewayRegex = new Regex("^R-\\d{1,4}$", RegexOptions.IgnoreCase);
+            int lastRow = sheet.UsedRange.Rows.Count;
+            Ductbank current = null;
+
+            for (int row = 1; row <= lastRow; row++)
+            {
+                var cell = (Excel.Range)sheet.Cells[row, idCol];
+                var text = cell.Text as string;
+                if (!string.IsNullOrWhiteSpace(text) && new Regex("^EDB-\\d{1,4}$", RegexOptions.IgnoreCase).IsMatch(text))
+                {
+                    current = new Ductbank { ID = text };
+                    ductbanks.Add(current);
+                }
+                else if ((cell.MergeCells as bool? ?? false) && current != null)
+                {
+                    // continue rows for the current ductbank
+                }
+                else
+                {
+                    current = null;
+                }
+
+                if (current != null)
+                {
+                    int lastCol = sheet.UsedRange.Columns.Count;
+                    for (int col = idCol + 1; col <= lastCol; col++)
+                    {
+                        var raceway = ((Excel.Range)sheet.Cells[row, col]).Text as string;
+                        if (racewayRegex.IsMatch(raceway ?? string.Empty))
+                        {
+                            current.Raceways.Add(raceway);
+                        }
+                    }
+                }
+            }
+            return ductbanks;
+        }
+
+        private List<CableTray> BuildCableTrayList(Excel.Worksheet sheet)
+        {
+            var trays = new List<CableTray>();
+            int idCol = FindFirstMatchColumn(sheet, new Regex("^ECT-\\d{1,4}$", RegexOptions.IgnoreCase));
+            if (idCol <= 0)
+            {
+                return trays;
+            }
+
+            var cableRegex = new Regex("^C-\\d{1,4}$", RegexOptions.IgnoreCase);
+            int lastRow = sheet.UsedRange.Rows.Count;
+            CableTray current = null;
+
+            for (int row = 1; row <= lastRow; row++)
+            {
+                var cell = (Excel.Range)sheet.Cells[row, idCol];
+                var text = cell.Text as string;
+                if (!string.IsNullOrWhiteSpace(text) && new Regex("^ECT-\\d{1,4}$", RegexOptions.IgnoreCase).IsMatch(text))
+                {
+                    current = new CableTray { ID = text };
+                    trays.Add(current);
+                }
+                else if ((cell.MergeCells as bool? ?? false) && current != null)
+                {
+                    // additional row for same tray
+                }
+                else
+                {
+                    current = null;
+                }
+
+                if (current != null)
+                {
+                    int lastCol = sheet.UsedRange.Columns.Count;
+                    for (int col = idCol + 1; col <= lastCol; col++)
+                    {
+                        var cable = ((Excel.Range)sheet.Cells[row, col]).Text as string;
+                        if (cableRegex.IsMatch(cable ?? string.Empty))
+                        {
+                            current.Cables.Add(cable);
+                        }
+                    }
+                }
+            }
+            return trays;
         }
 
         private void ApplyRacewaySizing(Excel.Worksheet sheet, TraceResult context)
@@ -194,6 +302,106 @@ namespace ArgusExcelTools
             return "Error";
         }
 
+        private void ValidateCableRaceway(List<Cable> cables, List<Raceway> raceways, string folder)
+        {
+            var log = new List<string>();
+            foreach (var cable in cables)
+            {
+                bool matchFound = false;
+                foreach (var raceway in raceways)
+                {
+                    if (cable.RacewayRouting != null && cable.RacewayRouting.IndexOf(raceway.ID, StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        if (raceway.CableFill == null || raceway.CableFill.IndexOf(cable.ID, StringComparison.OrdinalIgnoreCase) < 0)
+                        {
+                            log.Add($"Raceway {raceway.ID} is in Cable {cable.ID}, but {cable.ID} is not called out in the raceway tab.");
+                        }
+                        else
+                        {
+                            matchFound = true;
+                        }
+                    }
+                }
+
+                if (!matchFound && !string.IsNullOrEmpty(cable.RacewayRouting) &&
+                    cable.RacewayRouting.IndexOf("ECT", StringComparison.OrdinalIgnoreCase) < 0 &&
+                    cable.RacewayRouting != "-")
+                {
+                    log.Add($"Cable {cable.ID} has no corresponding raceway routing.");
+                }
+            }
+
+            WriteLog(Path.Combine(folder, "RacewayCableErrorLog.txt"), log);
+        }
+
+        private void ValidateDuctbank(List<Ductbank> ductbanks, List<Raceway> raceways, string folder)
+        {
+            var log = new List<string>();
+            foreach (var ductbank in ductbanks)
+            {
+                foreach (var racewayId in ductbank.Raceways)
+                {
+                    var raceway = raceways.FirstOrDefault(r => r.ID.Equals(racewayId, StringComparison.OrdinalIgnoreCase));
+                    if (raceway != null)
+                    {
+                        if (string.IsNullOrEmpty(raceway.DuctbankRouting) || raceway.DuctbankRouting.IndexOf(ductbank.ID, StringComparison.OrdinalIgnoreCase) < 0)
+                        {
+                            log.Add($"Raceway {racewayId} is listed in Ductbank {ductbank.ID}, but {ductbank.ID} is not in its DuctbankRouting.");
+                        }
+                    }
+                    else
+                    {
+                        log.Add($"Raceway {racewayId} is listed in Ductbank {ductbank.ID}, but does not exist in the raceway schedule.");
+                    }
+                }
+            }
+
+            WriteLog(Path.Combine(folder, "DuctbankErrorLog.txt"), log);
+        }
+
+        private void ValidateCableTray(List<CableTray> trays, List<Cable> cables, string folder)
+        {
+            var log = new List<string>();
+            foreach (var tray in trays)
+            {
+                foreach (var cableId in tray.Cables)
+                {
+                    var cable = cables.FirstOrDefault(c => c.ID.Equals(cableId, StringComparison.OrdinalIgnoreCase));
+                    if (cable != null)
+                    {
+                        if (string.IsNullOrEmpty(cable.RacewayRouting) || cable.RacewayRouting.IndexOf(tray.ID, StringComparison.OrdinalIgnoreCase) < 0)
+                        {
+                            log.Add($"Cable {cableId} is listed in Cable Tray {tray.ID}, but {tray.ID} is not in its Raceway Routing.");
+                        }
+                    }
+                    else
+                    {
+                        log.Add($"Cable {cableId} is listed in Cable Tray {tray.ID}, but does not exist in the cable schedule.");
+                    }
+                }
+            }
+
+            WriteLog(Path.Combine(folder, "CableTrayErrorLog.txt"), log);
+        }
+
+        private static void WriteLog(string path, List<string> entries)
+        {
+            using (var writer = new StreamWriter(path, false))
+            {
+                if (entries.Any())
+                {
+                    foreach (var entry in entries)
+                    {
+                        writer.WriteLine(entry);
+                    }
+                }
+                else
+                {
+                    writer.WriteLine("No errors found.");
+                }
+            }
+        }
+
         private static int FindColumnByHeader(Excel.Worksheet sheet, string header)
         {
             int maxCol = sheet.UsedRange.Columns.Count;
@@ -204,6 +412,24 @@ namespace ArgusExcelTools
                 {
                     var text = ((Excel.Range)sheet.Cells[row, col]).Text as string;
                     if (string.Equals(text?.Trim(), header, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return col;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        private static int FindFirstMatchColumn(Excel.Worksheet sheet, Regex pattern)
+        {
+            int maxCol = sheet.UsedRange.Columns.Count;
+            int maxRow = Math.Min(10, sheet.UsedRange.Rows.Count);
+            for (int col = 1; col <= maxCol; col++)
+            {
+                for (int row = 1; row <= maxRow; row++)
+                {
+                    var text = ((Excel.Range)sheet.Cells[row, col]).Text as string;
+                    if (pattern.IsMatch(text ?? string.Empty))
                     {
                         return col;
                     }

--- a/ArgusExcelTools/CableTray.cs
+++ b/ArgusExcelTools/CableTray.cs
@@ -1,19 +1,15 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace ArgusElectrical
+namespace ArgusExcelTools
 {
     internal class CableTray
     {
         public string ID { get; set; }
-        public List<string> Cables { get; set; }
+        public List<string> Cables { get; }
 
         public CableTray()
         {
-            List<string> Cables = new List<string>();
+            Cables = new List<string>();
         }
     }
 }

--- a/ArgusExcelTools/Ductbank.cs
+++ b/ArgusExcelTools/Ductbank.cs
@@ -1,19 +1,15 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace ArgusElectrical
+namespace ArgusExcelTools
 {
     internal class Ductbank
     {
         public string ID { get; set; }
-        public List<string> Raceways { get; set; }
+        public List<string> Raceways { get; }
 
         public Ductbank()
         {
-            List<string> Raceways = new List<string>();
+            Raceways = new List<string>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure Ductbank and CableTray classes initialize lists in the proper namespace
- extend cable trace processor to read ductbank and cable tray sheets
- validate cable, raceway, ductbank, and cable tray schedules and write error logs beside the workbook

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892d6c940b8832fa78bd604a34fc452